### PR TITLE
Fixed force loadUtils

### DIFF
--- a/src/international-phone-number.coffee
+++ b/src/international-phone-number.coffee
@@ -48,9 +48,6 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
       element.intlTelInput(options)
     , 500
 
-    unless options.utilsScript
-      element.intlTelInput('loadUtils', 'bower_components/intl-tel-input/lib/libphonenumber/build/utils.js')
-
     ctrl.$parsers.push (value) ->
       return value if !value
       if options.keepModelClean


### PR DESCRIPTION
Removed the forced `loadUtils` option.
The file should be referenced manually or use the `load-utils` attribute.
